### PR TITLE
Added a url cleaning decorator to non-safe-method calls to drc to rem…

### DIFF
--- a/src/dowc/core/tests/test_core_utils.py
+++ b/src/dowc/core/tests/test_core_utils.py
@@ -2,6 +2,7 @@ import uuid
 from urllib.parse import urlparse
 
 import requests_mock
+from furl import furl
 from rest_framework.test import APITestCase
 from zgw_consumers.api_models.base import factory
 from zgw_consumers.api_models.documenten import Document
@@ -50,8 +51,8 @@ class CoreUtilTests(APITestCase):
 
         # Create mock url for drc object
         _uuid = str(uuid.uuid4())
-        cls.doc_url = f"{cls.DRC_URL}enkelvoudiginformatieobjecten/{_uuid}"
-
+        cls.doc_url = f"{cls.DRC_URL}enkelvoudiginformatieobjecten/{_uuid}?versie=10"
+        cls.doc_url_nonget = f"{cls.DRC_URL}enkelvoudiginformatieobjecten/{_uuid}"
         cls.doc_data = generate_oas_component(
             "drc",
             "schemas/EnkelvoudigInformatieObject",
@@ -83,10 +84,10 @@ class CoreUtilTests(APITestCase):
         mock_service_oas_get(m, self.DRC_URL, "drc")
 
         lock = "some-lock"
-        m.post(self.doc_url + "/lock", json={"lock": lock})
+        m.post(self.doc_url_nonget + "/lock", json={"lock": lock})
 
         client = self.service.get_client(self.doc_url)
-        response = lock_document(self.doc_url, client=client)
+        response = lock_document(self.doc_url_nonget, client=client)
         self.assertEqual(lock, response)
 
     def test_lock_document_without_passing_client(self, m):
@@ -94,9 +95,9 @@ class CoreUtilTests(APITestCase):
         mock_service_oas_get(m, self.DRC_URL, "drc")
 
         lock = "some-lock"
-        m.post(self.doc_url + "/lock", json={"lock": lock})
+        m.post(self.doc_url_nonget + "/lock", json={"lock": lock})
 
-        response = lock_document(self.doc_url)
+        response = lock_document(self.doc_url_nonget)
         self.assertEqual(lock, response)
 
     def test_unlock_document_with_passing_client(self, m):
@@ -106,8 +107,8 @@ class CoreUtilTests(APITestCase):
         # Mock drc_client service
         mock_service_oas_get(m, self.DRC_URL, "drc")
 
-        m.post(self.doc_url + "/unlock", status_code=204)
-        m.get(self.doc_url, json={**self.doc_data, "versie": 42})
+        m.post(self.doc_url_nonget + "/unlock", status_code=204)
+        m.get(self.doc_url_nonget, json={**self.doc_data, "versie": 42})
 
         lock = "some-lock"
         client = self.service.get_client(self.doc_url)
@@ -120,8 +121,8 @@ class CoreUtilTests(APITestCase):
         """
         # Mock drc_client service
         mock_service_oas_get(m, self.DRC_URL, "drc")
-        m.post(self.doc_url + "/unlock", status_code=204)
-        m.get(self.doc_url, json={**self.doc_data, "versie": 42})
+        m.post(self.doc_url_nonget + "/unlock", status_code=204)
+        m.get(self.doc_url_nonget, json={**self.doc_data, "versie": 42})
 
         lock = "some-lock"
 
@@ -136,7 +137,7 @@ class CoreUtilTests(APITestCase):
         """
         # Mock drc_client service
         mock_service_oas_get(m, self.DRC_URL, "drc")
-        m.post(self.doc_url + "/unlock", status_code=200)
+        m.post(self.doc_url_nonget + "/unlock", status_code=200)
 
         lock = "some-lock"
         with self.assertRaises(AssertionError):
@@ -145,7 +146,7 @@ class CoreUtilTests(APITestCase):
     def test_update_document_with_passing_client(self, m):
         # Mock drc_client service
         mock_service_oas_get(m, self.DRC_URL, "drc")
-        m.patch(self.doc_url, json=self.doc_data)
+        m.patch(self.doc_url_nonget, json=self.doc_data)
         client = self.service.get_client(self.doc_url)
 
         response = update_document(self.doc_url, self.doc_data, client=client)
@@ -155,7 +156,7 @@ class CoreUtilTests(APITestCase):
     def test_update_document_without_passing_client(self, m):
         # Mock drc_client service
         mock_service_oas_get(m, self.DRC_URL, "drc")
-        m.patch(self.doc_url, json=self.doc_data)
+        m.patch(self.doc_url_nonget, json=self.doc_data)
 
         response = update_document(self.doc_url, self.doc_data)
 


### PR DESCRIPTION
…ove versie from url.

The DRC doesn't accept a post/patch/put call to a url that specifies the version of the document (obvious in hindsight...).