### PR TITLE
:sparkles: Add django.contrib.sites to build absolute url

### DIFF
--- a/src/dowc/api/serializers.py
+++ b/src/dowc/api/serializers.py
@@ -1,5 +1,6 @@
 import os
 
+from django.contrib.sites.models import Site
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -147,21 +148,18 @@ class DocumentFileSerializer(serializers.ModelSerializer):
             else:
                 command_argument = ":ofe|u|"
 
-        url = self.context["request"].build_absolute_uri(
-            reverse(
-                "core:webdav-document",
-                kwargs={
-                    "uuid": str(obj.uuid),
-                    "token": document_token_generator.make_token(
-                        obj.user, str(obj.uuid)
-                    ),
-                    "purpose": obj.purpose,
-                    "path": obj.document.name,
-                },
-            )
+        domain = furl(Site.objects.get_current().domain)
+        url = reverse(
+            "core:webdav-document",
+            kwargs={
+                "uuid": str(obj.uuid),
+                "token": document_token_generator.make_token(obj.user, str(obj.uuid)),
+                "purpose": obj.purpose,
+                "path": obj.document.name,
+            },
         )
-
-        return f"{scheme_name}{command_argument}{url}"
+        domain.path = url
+        return f"{scheme_name}{command_argument}{domain.url}"
 
 
 class UnlockedDocumentSerializer(APIModelSerializer):

--- a/src/dowc/api/tests/test_serializers.py
+++ b/src/dowc/api/tests/test_serializers.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.contrib.sites.models import Site
 from django.test import override_settings
-from django.test.client import RequestFactory
 
 from rest_framework import status
 from rest_framework.reverse import reverse_lazy
@@ -95,7 +95,7 @@ class DocumentFileSerializerTests(APITestCase):
         )
 
         result = DocumentFileSerializer(docfile)
-        result.context["request"] = RequestFactory().post(self.list_url)
+
         # Assert presence of magic_url in result.data
         self.assertIn("magic_url", result.data)
         magic_url = result.data["magic_url"]
@@ -149,12 +149,15 @@ class DocumentFileSerializerTests(APITestCase):
         This tests if the magic url finds the document file object and the document.
         """
 
+        site = Site.objects.get()
+        site.domain = "http://some-dowc.com/"
+        site.save()
+
         docfile = DocumentFileFactory.create(
             drc_url=self.doc_url, purpose=DocFileTypes.read, user=self.user
         )
 
         result = DocumentFileSerializer(docfile)
-        result.context["request"] = RequestFactory().post(self.list_url)
 
         # Assert presence of magic_url in result.data
         self.assertIn("magic_url", result.data)

--- a/src/dowc/conf/includes/base.py
+++ b/src/dowc/conf/includes/base.py
@@ -17,6 +17,7 @@ BASE_DIR = os.path.abspath(
 #
 # Core Django settings
 #
+SITE_ID = config("SITE_ID", default=1)
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = config("SECRET_KEY")
@@ -86,7 +87,7 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.sessions",
     # Note: If enabled, at least one Site object is required
-    # 'django.contrib.sites',
+    "django.contrib.sites",
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.postgres",


### PR DESCRIPTION
Related to use of internal urls instead of public urls. Can't rely on Django's HttpRequest.build_absolute_url anymore.